### PR TITLE
SickChill - Go Live (Replaces linuxserver/docker-sickrage) 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM lsiobase/alpine.python:3.9
 # set version label
 ARG BUILD_DATE
 ARG VERSION
-ARG SICKCHILL_RELEASE
+ARG SICKCHILL_COMMIT
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
 LABEL maintainer="homerr"
 
@@ -11,20 +11,21 @@ LABEL maintainer="homerr"
 ENV PYTHONIOENCODING="UTF-8"
 
 RUN \
- echo "**** upgrade packages ****" && \
- apk add --no-cache --upgrade && \
+echo "**** upgrade packages ****" && \
+apk add --no-cache --upgrade && \
 echo "**** fetch sickchill ****" && \
- mkdir -p\
+mkdir -p \
 	/app/sickchill && \
- if [ -z ${SICKCHILL_RELEASE}+x} ]; then \
- SICKCHILL_RELEASE=$(curl -sX GET "https://api.github.com/repos/sickchill/sickchill/releases/latest" \
-	| awk '/tag_name/{print $4;exit}' FS='[""]'); \
- fi && \
- curl -o \
- /tmp/sickchill.tar.gz -L \
-	"https://github.com/sickchill/sickchill/archive/${SICKCHILL_RELEASE}.tar.gz" && \
- tar xf \
- /tmp/sickchill.tar.gz -C \
+if [ -z ${SICKCHILL_COMMIT}+x} ]; then \
+	SICKCHILL_COMMIT=$(curl -sX GET "https://api.github.com/repos/sickchill/sickchill/commits/master" \
+	| awk '/sha/{print $4;exit}' FS='[""]'); \
+fi && \
+echo "found ${SICKCHILL_COMMIT}" && \
+curl -o \
+/tmp/sickchill.tar.gz -L \
+	"https://github.com/sickchill/sickchill/archive/${SICKCHILL_COMMIT}.tar.gz" && \
+tar xf \
+	/tmp/sickchill.tar.gz -C \
 	/app/sickchill/ --strip-components=1
 
 # copy local files

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,8 @@ apk add --no-cache --upgrade && \
 echo "**** fetch sickchill ****" && \
 mkdir -p \
 	/app/sickchill && \
-if [ -z ${SICKCHILL_COMMIT}+x} ]; then \
-	SICKCHILL_COMMIT=$(curl -sX GET "https://api.github.com/repos/sickchill/sickchill/commits/master" \
+if [ -z ${SICKCHILL_COMMIT+x} ]; then \
+	SICKCHILL_COMMIT=$(curl -sX GET https://api.github.com/repos/sickchill/sickchill/commits/master \
 	| awk '/sha/{print $4;exit}' FS='[""]'); \
 fi && \
 echo "found ${SICKCHILL_COMMIT}" && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,31 @@
-FROM lsiobase/alpine.python:3.8
+FROM lsiobase/alpine.python:3.9
 
 # set version label
 ARG BUILD_DATE
 ARG VERSION
+ARG SICKCHILL_RELEASE
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
 LABEL maintainer="homerr"
-
-# package versions
-ARG SICKCHILL_RELEASE
 
 # set python to use utf-8 rather than ascii
 ENV PYTHONIOENCODING="UTF-8"
 
 RUN \
- echo "**** install packages ****" && \
- apk add --no-cache \
-	--repository http://nl.alpinelinux.org/alpine/edge/main \
-	nodejs && \
- echo "**** install app ****" && \
- git clone --depth=1 https://github.com/SickChill/SickChill.git /app/sickchill
+ echo "**** upgrade packages ****" && \
+ apk add --no-cache --upgrade && \
+echo "**** fetch sickchill ****" && \
+ mkdir -p\
+	/app/sickchill && \
+ if [ -z ${SICKCHILL_RELEASE}+x} ]; then \
+ SICKCHILL_RELEASE=$(curl -sX GET "https://api.github.com/repos/sickchill/sickchill/releases/latest" \
+	| awk '/tag_name/{print $4;exit}' FS='[""]'); \
+ fi && \
+ curl -o \
+ /tmp/sickchill.tar.gz -L \
+	"https://github.com/sickchill/sickchill/archive/${SICKCHILL_RELEASE}.tar.gz" && \
+ tar xf \
+ /tmp/sickchill.tar.gz -C \
+	/app/sickchill/ --strip-components=1
 
 # copy local files
 COPY root/ /

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,4 +1,4 @@
-FROM lsiobase/alpine.python.arm64:3.8
+FROM lsiobase/alpine.python:3.9
 
 # Add qemu to build on x86_64 systems
 COPY qemu-aarch64-static /usr/bin
@@ -6,22 +6,29 @@ COPY qemu-aarch64-static /usr/bin
 # set version label
 ARG BUILD_DATE
 ARG VERSION
+ARG SICKCHILL_RELEASE
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
 LABEL maintainer="homerr"
-
-# package versions
-ARG SICKCHILL_RELEASE
 
 # set python to use utf-8 rather than ascii
 ENV PYTHONIOENCODING="UTF-8"
 
 RUN \
- echo "**** install packages ****" && \
- apk add --no-cache \
-	--repository http://nl.alpinelinux.org/alpine/edge/main \
-	nodejs && \
- echo "**** install app ****" && \
- git clone --depth=1 https://github.com/SickChill/SickChill.git /app/sickchill
+ echo "**** upgrade packages ****" && \
+ apk add --no-cache --upgrade && \
+echo "**** fetch sickchill ****" && \
+ mkdir -p\
+	/app/sickchill && \
+ if [ -z ${SICKCHILL_RELEASE}+x} ]; then \
+ SICKCHILL_RELEASE=$(curl -sX GET "https://api.github.com/repos/sickchill/sickchill/releases/latest" \
+	| awk '/tag_name/{print $4;exit}' FS='[""]'); \
+ fi && \
+ curl -o \
+ /tmp/sickchill.tar.gz -L \
+	"https://github.com/sickchill/sickchill/archive/${SICKCHILL_RELEASE}.tar.gz" && \
+ tar xf \
+ /tmp/sickchill.tar.gz -C \
+	/app/sickchill/ --strip-components=1
 
 # copy local files
 COPY root/ /

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,4 +1,4 @@
-FROM lsiobase/alpine.python:3.9
+FROM lsiobase/alpine.python.arm64:3.9
 
 # Add qemu to build on x86_64 systems
 COPY qemu-aarch64-static /usr/bin

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -19,8 +19,8 @@ apk add --no-cache --upgrade && \
 echo "**** fetch sickchill ****" && \
 mkdir -p \
 	/app/sickchill && \
-if [ -z ${SICKCHILL_COMMIT}+x} ]; then \
-	SICKCHILL_COMMIT=$(curl -sX GET "https://api.github.com/repos/sickchill/sickchill/commits/master" \
+if [ -z ${SICKCHILL_COMMIT+x} ]; then \
+	SICKCHILL_COMMIT=$(curl -sX GET https://api.github.com/repos/sickchill/sickchill/commits/master \
 	| awk '/sha/{print $4;exit}' FS='[""]'); \
 fi && \
 echo "found ${SICKCHILL_COMMIT}" && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -14,20 +14,21 @@ LABEL maintainer="homerr"
 ENV PYTHONIOENCODING="UTF-8"
 
 RUN \
- echo "**** upgrade packages ****" && \
- apk add --no-cache --upgrade && \
+echo "**** upgrade packages ****" && \
+apk add --no-cache --upgrade && \
 echo "**** fetch sickchill ****" && \
- mkdir -p\
+mkdir -p \
 	/app/sickchill && \
- if [ -z ${SICKCHILL_RELEASE}+x} ]; then \
- SICKCHILL_RELEASE=$(curl -sX GET "https://api.github.com/repos/sickchill/sickchill/releases/latest" \
-	| awk '/tag_name/{print $4;exit}' FS='[""]'); \
- fi && \
- curl -o \
- /tmp/sickchill.tar.gz -L \
-	"https://github.com/sickchill/sickchill/archive/${SICKCHILL_RELEASE}.tar.gz" && \
- tar xf \
- /tmp/sickchill.tar.gz -C \
+if [ -z ${SICKCHILL_COMMIT}+x} ]; then \
+	SICKCHILL_COMMIT=$(curl -sX GET "https://api.github.com/repos/sickchill/sickchill/commits/master" \
+	| awk '/sha/{print $4;exit}' FS='[""]'); \
+fi && \
+echo "found ${SICKCHILL_COMMIT}" && \
+curl -o \
+/tmp/sickchill.tar.gz -L \
+	"https://github.com/sickchill/sickchill/archive/${SICKCHILL_COMMIT}.tar.gz" && \
+tar xf \
+	/tmp/sickchill.tar.gz -C \
 	/app/sickchill/ --strip-components=1
 
 # copy local files

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -1,4 +1,4 @@
-FROM lsiobase/alpine.python:3.9
+FROM lsiobase/alpine.python.armhf:3.9
 
 # Add qemu to build on x86_64 systems
 COPY qemu-arm-static /usr/bin

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -1,4 +1,4 @@
-FROM lsiobase/alpine.python.armhf:3.8
+FROM lsiobase/alpine.python:3.9
 
 # Add qemu to build on x86_64 systems
 COPY qemu-arm-static /usr/bin
@@ -6,22 +6,29 @@ COPY qemu-arm-static /usr/bin
 # set version label
 ARG BUILD_DATE
 ARG VERSION
+ARG SICKCHILL_RELEASE
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
 LABEL maintainer="homerr"
-
-# package versions
-ARG SICKCHILL_RELEASE
 
 # set python to use utf-8 rather than ascii
 ENV PYTHONIOENCODING="UTF-8"
 
 RUN \
- echo "**** install packages ****" && \
- apk add --no-cache \
-	--repository http://nl.alpinelinux.org/alpine/edge/main \
-	nodejs && \
- echo "**** install app ****" && \
- git clone --depth=1 https://github.com/SickChill/SickChill.git /app/sickchill
+ echo "**** upgrade packages ****" && \
+ apk add --no-cache --upgrade && \
+echo "**** fetch sickchill ****" && \
+ mkdir -p\
+	/app/sickchill && \
+ if [ -z ${SICKCHILL_RELEASE}+x} ]; then \
+ SICKCHILL_RELEASE=$(curl -sX GET "https://api.github.com/repos/sickchill/sickchill/releases/latest" \
+	| awk '/tag_name/{print $4;exit}' FS='[""]'); \
+ fi && \
+ curl -o \
+ /tmp/sickchill.tar.gz -L \
+	"https://github.com/sickchill/sickchill/archive/${SICKCHILL_RELEASE}.tar.gz" && \
+ tar xf \
+ /tmp/sickchill.tar.gz -C \
+	/app/sickchill/ --strip-components=1
 
 # copy local files
 COPY root/ /

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -19,8 +19,8 @@ apk add --no-cache --upgrade && \
 echo "**** fetch sickchill ****" && \
 mkdir -p \
 	/app/sickchill && \
-if [ -z ${SICKCHILL_COMMIT}+x} ]; then \
-	SICKCHILL_COMMIT=$(curl -sX GET "https://api.github.com/repos/sickchill/sickchill/commits/master" \
+if [ -z ${SICKCHILL_COMMIT+x} ]; then \
+	SICKCHILL_COMMIT=$(curl -sX GET https://api.github.com/repos/sickchill/sickchill/commits/master \
 	| awk '/sha/{print $4;exit}' FS='[""]'); \
 fi && \
 echo "found ${SICKCHILL_COMMIT}" && \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -14,20 +14,21 @@ LABEL maintainer="homerr"
 ENV PYTHONIOENCODING="UTF-8"
 
 RUN \
- echo "**** upgrade packages ****" && \
- apk add --no-cache --upgrade && \
+echo "**** upgrade packages ****" && \
+apk add --no-cache --upgrade && \
 echo "**** fetch sickchill ****" && \
- mkdir -p\
+mkdir -p \
 	/app/sickchill && \
- if [ -z ${SICKCHILL_RELEASE}+x} ]; then \
- SICKCHILL_RELEASE=$(curl -sX GET "https://api.github.com/repos/sickchill/sickchill/releases/latest" \
-	| awk '/tag_name/{print $4;exit}' FS='[""]'); \
- fi && \
- curl -o \
- /tmp/sickchill.tar.gz -L \
-	"https://github.com/sickchill/sickchill/archive/${SICKCHILL_RELEASE}.tar.gz" && \
- tar xf \
- /tmp/sickchill.tar.gz -C \
+if [ -z ${SICKCHILL_COMMIT}+x} ]; then \
+	SICKCHILL_COMMIT=$(curl -sX GET "https://api.github.com/repos/sickchill/sickchill/commits/master" \
+	| awk '/sha/{print $4;exit}' FS='[""]'); \
+fi && \
+echo "found ${SICKCHILL_COMMIT}" && \
+curl -o \
+/tmp/sickchill.tar.gz -L \
+	"https://github.com/sickchill/sickchill/archive/${SICKCHILL_COMMIT}.tar.gz" && \
+tar xf \
+	/tmp/sickchill.tar.gz -C \
 	/app/sickchill/ --strip-components=1
 
 # copy local files

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,11 +2,17 @@ pipeline {
   agent {
     label 'X86-64-MULTI'
   }
+  // Input to determine if this is a package check
+  parameters {
+     string(defaultValue: 'false', description: 'package check run', name: 'PACKAGE_CHECK')
+  }
   // Configuration for the variables used for this specific repo
   environment {
+    BUILDS_DISCORD=credentials('build_webhook_url')
+    GITHUB_TOKEN=credentials('498b4638-2d02-4ce5-832d-8a57d01d97ab')
     EXT_GIT_BRANCH = 'master'
-    EXT_USER = 'SickChill'
-    EXT_REPO = 'SickChill'
+    EXT_USER = 'sickchill'
+    EXT_REPO = 'sickchill'
     BUILD_VERSION_ARG = 'SICKCHILL_RELEASE'
     LS_USER = 'linuxserver'
     LS_REPO = 'docker-sickchill'
@@ -14,19 +20,14 @@ pipeline {
     DOCKERHUB_IMAGE = 'linuxserver/sickchill'
     DEV_DOCKERHUB_IMAGE = 'lsiodev/sickchill'
     PR_DOCKERHUB_IMAGE = 'lspipepr/sickchill'
-    BUILDS_DISCORD = credentials('build_webhook_url')
-    GITHUB_TOKEN = credentials('498b4638-2d02-4ce5-832d-8a57d01d97ab')
     DIST_IMAGE = 'alpine'
-    DIST_TAG = '3.8'
-    DIST_PACKAGES = 'nodejs'
     MULTIARCH = 'true'
     CI = 'true'
     CI_WEB = 'true'
-    CI_PORT = '80'
+    CI_PORT = '8081'
     CI_SSL = 'false'
-    CI_DELAY = '10'
-    TEST_MYSQL_HOST = credentials('mysql_test_host')
-    TEST_MYSQL_PASSWORD = credentials('mysql_test_password')
+    CI_DELAY = '120'
+    CI_DOCKERENV = 'TZ=Europe/London'
     CI_AUTH = 'user:password'
     CI_WEBPATH = ''
   }
@@ -35,6 +36,7 @@ pipeline {
     stage("Set ENV Variables base"){
       steps{
         script{
+          env.EXIT_STATUS = ''
           env.LS_RELEASE = sh(
             script: '''curl -s https://api.github.com/repos/${LS_USER}/${LS_REPO}/releases/latest | jq -r '. | .tag_name' ''',
             returnStdout: true).trim()
@@ -74,14 +76,21 @@ pipeline {
     /* #######################
        Package Version Tagging
        ####################### */
-    // If this is an alpine base image determine the base package tag to use
-    stage("Set Package tag Alpine"){
+    // Grab the current package versions in Git to determine package tag
+    stage("Set Package tag"){
       steps{
-        sh '''docker pull alpine:${DIST_TAG}'''
         script{
           env.PACKAGE_TAG = sh(
-            script: '''docker run --rm alpine:${DIST_TAG} sh -c 'apk update --quiet\
-                       && apk info '"${DIST_PACKAGES}"' | md5sum | cut -c1-8' ''',
+            script: '''#!/bin/bash
+                       http_code=$(curl --write-out %{http_code} -s -o /dev/null \
+                                   https://raw.githubusercontent.com/${LS_USER}/${LS_REPO}/master/package_versions.txt)
+                       if [[ "${http_code}" -ne 200 ]] ; then
+                         echo none
+                       else
+                         curl -s \
+                           https://raw.githubusercontent.com/${LS_USER}/${LS_REPO}/master/package_versions.txt \
+                         | md5sum | cut -c1-8
+                       fi''',
             returnStdout: true).trim()
         }
       }
@@ -163,8 +172,8 @@ pipeline {
         }
       }
     }
-    // Use helper container to render a readme from the template if needed
-    stage('Update-README') {
+    // Use helper containers to render templated files
+    stage('Update-Templates') {
       when {
         branch "master"
         environment name: 'CHANGE_ID', value: ''
@@ -174,126 +183,207 @@ pipeline {
       }
       steps {
         sh '''#! /bin/bash
+              set -e
               TEMPDIR=$(mktemp -d)
+              docker pull linuxserver/jenkins-builder:latest
+              docker run --rm -e CONTAINER_NAME=${CONTAINER_NAME} -e GITHUB_BRANCH=master -v ${TEMPDIR}:/ansible/jenkins linuxserver/jenkins-builder:latest 
               docker pull linuxserver/doc-builder:latest
-              docker run --rm -e CONTAINER_NAME=${CONTAINER_NAME} -v ${TEMPDIR}:/ansible/readme linuxserver/doc-builder:latest
-              if [ "$(md5sum ${TEMPDIR}/${CONTAINER_NAME}/README.md | awk '{ print $1 }')" != "$(md5sum README.md | awk '{ print $1 }')" ]; then
-                git clone https://github.com/${LS_USER}/${LS_REPO}.git ${TEMPDIR}/${LS_REPO}
-                cp ${TEMPDIR}/${CONTAINER_NAME}/README.md ${TEMPDIR}/${LS_REPO}/
-                cd ${TEMPDIR}/${LS_REPO}/
-                git --git-dir ${TEMPDIR}/${LS_REPO}/.git add README.md
-                git --git-dir ${TEMPDIR}/${LS_REPO}/.git commit -m 'Bot Updating README from template'
-                git --git-dir ${TEMPDIR}/${LS_REPO}/.git push https://LinuxServer-CI:${GITHUB_TOKEN}@github.com/${LS_USER}/${LS_REPO}.git --all
+              docker run --rm -e CONTAINER_NAME=${CONTAINER_NAME} -e GITHUB_BRANCH=master -v ${TEMPDIR}:/ansible/readme linuxserver/doc-builder:latest
+              if [ "$(md5sum ${TEMPDIR}/${LS_REPO}/Jenkinsfile | awk '{ print $1 }')" != "$(md5sum Jenkinsfile | awk '{ print $1 }')" ] || [ "$(md5sum ${TEMPDIR}/${CONTAINER_NAME}/README.md | awk '{ print $1 }')" != "$(md5sum README.md | awk '{ print $1 }')" ]; then
+                mkdir -p ${TEMPDIR}/repo
+                git clone https://github.com/${LS_USER}/${LS_REPO}.git ${TEMPDIR}/repo/${LS_REPO}
+                git --git-dir ${TEMPDIR}/repo/${LS_REPO}/.git checkout -f master
+                cp ${TEMPDIR}/${CONTAINER_NAME}/README.md ${TEMPDIR}/repo/${LS_REPO}/
+                cp ${TEMPDIR}/docker-${CONTAINER_NAME}/Jenkinsfile ${TEMPDIR}/repo/${LS_REPO}/
+                cd ${TEMPDIR}/repo/${LS_REPO}/
+                git --git-dir ${TEMPDIR}/repo/${LS_REPO}/.git add Jenkinsfile README.md
+                git --git-dir ${TEMPDIR}/repo/${LS_REPO}/.git commit -m 'Bot Updating Templated Files'
+                git --git-dir ${TEMPDIR}/repo/${LS_REPO}/.git push https://LinuxServer-CI:${GITHUB_TOKEN}@github.com/${LS_USER}/${LS_REPO}.git --all
                 echo "true" > /tmp/${COMMIT_SHA}-${BUILD_NUMBER}
               else
                 echo "false" > /tmp/${COMMIT_SHA}-${BUILD_NUMBER}
               fi
               rm -Rf ${TEMPDIR}'''
         script{
-          env.README_UPDATED = sh(
+          env.FILES_UPDATED = sh(
             script: '''cat /tmp/${COMMIT_SHA}-${BUILD_NUMBER}''',
             returnStdout: true).trim()
         }
       }
     }
-    // Exit the build if the Readme was just updated
-    stage('README-exit') {
+    // Exit the build if the Templated files were just updated
+    stage('Template-exit') {
       when {
         branch "master"
         environment name: 'CHANGE_ID', value: ''
-        environment name: 'README_UPDATED', value: 'true'
+        environment name: 'FILES_UPDATED', value: 'true'
         expression {
           env.CONTAINER_NAME != null
         }
       }
       steps {
         script{
-          env.CI_URL = 'README_UPDATE'
-          env.RELEASE_LINK = 'README_UPDATE'
-          currentBuild.rawBuild.result = Result.ABORTED
-          throw new hudson.AbortException('ABORTED_README')
+          env.EXIT_STATUS = 'ABORTED'
         }
       }
     }
     /* ###############
        Build Container
        ############### */
-     // Build Docker container for push to LS Repo
-     stage('Build-Single') {
-       when {
-         environment name: 'MULTIARCH', value: 'false'
-       }
-       steps {
-         sh "docker build --no-cache -t ${IMAGE}:${META_TAG} \
-         --build-arg ${BUILD_VERSION_ARG}=${EXT_RELEASE} --build-arg VERSION=\"${META_TAG}\" --build-arg BUILD_DATE=${GITHUB_DATE} ."
-       }
-     }
-     // Build MultiArch Docker containers for push to LS Repo
-     stage('Build-Multi') {
-       when {
-         environment name: 'MULTIARCH', value: 'true'
-       }
-       parallel {
-         stage('Build X86') {
-           steps {
-             sh "docker build --no-cache -t ${IMAGE}:amd64-${META_TAG} \
-             --build-arg ${BUILD_VERSION_ARG}=${EXT_RELEASE} --build-arg VERSION=\"${META_TAG}\" --build-arg BUILD_DATE=${GITHUB_DATE} ."
-           }
-         }
-         stage('Build ARMHF') {
-           agent {
-             label 'ARMHF'
-           }
-           steps {
-             withCredentials([
-               [
-                 $class: 'UsernamePasswordMultiBinding',
-                 credentialsId: '3f9ba4d5-100d-45b0-a3c4-633fd6061207',
-                 usernameVariable: 'DOCKERUSER',
-                 passwordVariable: 'DOCKERPASS'
-               ]
-             ]) {
-               echo 'Logging into DockerHub'
-               sh '''#! /bin/bash
-                  echo $DOCKERPASS | docker login -u $DOCKERUSER --password-stdin
-                  '''
-               sh "curl https://lsio-ci.ams3.digitaloceanspaces.com/qemu-arm-static -o qemu-arm-static"
-               sh "chmod +x qemu-*"
-               sh "docker build --no-cache -f Dockerfile.armhf -t ${IMAGE}:arm32v6-${META_TAG} \
-                            --build-arg ${BUILD_VERSION_ARG}=${EXT_RELEASE} --build-arg VERSION=\"${META_TAG}\" --build-arg BUILD_DATE=${GITHUB_DATE} ."
-               sh "docker tag ${IMAGE}:arm32v6-${META_TAG} lsiodev/buildcache:arm32v6-${COMMIT_SHA}-${BUILD_NUMBER}"
-               sh "docker push lsiodev/buildcache:arm32v6-${COMMIT_SHA}-${BUILD_NUMBER}"
-             }
-           }
-         }
-         stage('Build ARM64') {
-           agent {
-             label 'ARM64'
-           }
-           steps {
-             withCredentials([
-               [
-                 $class: 'UsernamePasswordMultiBinding',
-                 credentialsId: '3f9ba4d5-100d-45b0-a3c4-633fd6061207',
-                 usernameVariable: 'DOCKERUSER',
-                 passwordVariable: 'DOCKERPASS'
-               ]
-             ]) {
-               echo 'Logging into DockerHub'
-               sh '''#! /bin/bash
-                  echo $DOCKERPASS | docker login -u $DOCKERUSER --password-stdin
-                  '''
-               sh "curl https://lsio-ci.ams3.digitaloceanspaces.com/qemu-aarch64-static -o qemu-aarch64-static"
-               sh "chmod +x qemu-*"
-               sh "docker build --no-cache -f Dockerfile.aarch64 -t ${IMAGE}:arm64v8-${META_TAG} \
-                            --build-arg ${BUILD_VERSION_ARG}=${EXT_RELEASE} --build-arg VERSION=\"${META_TAG}\" --build-arg BUILD_DATE=${GITHUB_DATE} ."
-               sh "docker tag ${IMAGE}:arm64v8-${META_TAG} lsiodev/buildcache:arm64v8-${COMMIT_SHA}-${BUILD_NUMBER}"
-               sh "docker push lsiodev/buildcache:arm64v8-${COMMIT_SHA}-${BUILD_NUMBER}"
-             }
-           }
-         }
-       }
-     }
+    // Build Docker container for push to LS Repo
+    stage('Build-Single') {
+      when {
+        environment name: 'MULTIARCH', value: 'false'
+        environment name: 'EXIT_STATUS', value: ''
+      }
+      steps {
+        sh "docker build --no-cache -t ${IMAGE}:${META_TAG} \
+        --build-arg ${BUILD_VERSION_ARG}=${EXT_RELEASE} --build-arg VERSION=\"${META_TAG}\" --build-arg BUILD_DATE=${GITHUB_DATE} ."
+      }
+    }
+    // Build MultiArch Docker containers for push to LS Repo
+    stage('Build-Multi') {
+      when {
+        environment name: 'MULTIARCH', value: 'true'
+        environment name: 'EXIT_STATUS', value: ''
+      }
+      parallel {
+        stage('Build X86') {
+          steps {
+            sh "docker build --no-cache -t ${IMAGE}:amd64-${META_TAG} \
+            --build-arg ${BUILD_VERSION_ARG}=${EXT_RELEASE} --build-arg VERSION=\"${META_TAG}\" --build-arg BUILD_DATE=${GITHUB_DATE} ."
+          }
+        }
+        stage('Build ARMHF') {
+          agent {
+            label 'ARMHF'
+          }
+          steps {
+            withCredentials([
+              [
+                $class: 'UsernamePasswordMultiBinding',
+                credentialsId: '3f9ba4d5-100d-45b0-a3c4-633fd6061207',
+                usernameVariable: 'DOCKERUSER',
+                passwordVariable: 'DOCKERPASS'
+              ]
+            ]) {
+              echo 'Logging into DockerHub'
+              sh '''#! /bin/bash
+                 echo $DOCKERPASS | docker login -u $DOCKERUSER --password-stdin
+                 '''
+              sh "curl https://lsio-ci.ams3.digitaloceanspaces.com/qemu-arm-static -o qemu-arm-static"
+              sh "chmod +x qemu-*"
+              sh "docker build --no-cache -f Dockerfile.armhf -t ${IMAGE}:arm32v6-${META_TAG} \
+                           --build-arg ${BUILD_VERSION_ARG}=${EXT_RELEASE} --build-arg VERSION=\"${META_TAG}\" --build-arg BUILD_DATE=${GITHUB_DATE} ."
+              sh "docker tag ${IMAGE}:arm32v6-${META_TAG} lsiodev/buildcache:arm32v6-${COMMIT_SHA}-${BUILD_NUMBER}"
+              sh "docker push lsiodev/buildcache:arm32v6-${COMMIT_SHA}-${BUILD_NUMBER}"
+            }
+          }
+        }
+        stage('Build ARM64') {
+          agent {
+            label 'ARM64'
+          }
+          steps {
+            withCredentials([
+              [
+                $class: 'UsernamePasswordMultiBinding',
+                credentialsId: '3f9ba4d5-100d-45b0-a3c4-633fd6061207',
+                usernameVariable: 'DOCKERUSER',
+                passwordVariable: 'DOCKERPASS'
+              ]
+            ]) {
+              echo 'Logging into DockerHub'
+              sh '''#! /bin/bash
+                 echo $DOCKERPASS | docker login -u $DOCKERUSER --password-stdin
+                 '''
+              sh "curl https://lsio-ci.ams3.digitaloceanspaces.com/qemu-aarch64-static -o qemu-aarch64-static"
+              sh "chmod +x qemu-*"
+              sh "docker build --no-cache -f Dockerfile.aarch64 -t ${IMAGE}:arm64v8-${META_TAG} \
+                           --build-arg ${BUILD_VERSION_ARG}=${EXT_RELEASE} --build-arg VERSION=\"${META_TAG}\" --build-arg BUILD_DATE=${GITHUB_DATE} ."
+              sh "docker tag ${IMAGE}:arm64v8-${META_TAG} lsiodev/buildcache:arm64v8-${COMMIT_SHA}-${BUILD_NUMBER}"
+              sh "docker push lsiodev/buildcache:arm64v8-${COMMIT_SHA}-${BUILD_NUMBER}"
+            }
+          }
+        }
+      }
+    }
+    // Take the image we just built and dump package versions for comparison
+    stage('Update-packages') {
+      when {
+        branch "master"
+        environment name: 'CHANGE_ID', value: ''
+        environment name: 'EXIT_STATUS', value: ''
+      }
+      steps {
+        sh '''#! /bin/bash
+              set -e
+              TEMPDIR=$(mktemp -d)
+              if [ "${MULTIARCH}" == "true" ]; then
+                LOCAL_CONTAINER=${IMAGE}:amd64-${META_TAG}
+              else
+                LOCAL_CONTAINER=${IMAGE}:${META_TAG}
+              fi
+              if [ "${DIST_IMAGE}" == "alpine" ]; then
+                docker run --rm --entrypoint '/bin/sh' -v ${TEMPDIR}:/tmp ${LOCAL_CONTAINER} -c '\
+                  apk info > packages && \
+                  apk info -v > versions && \
+                  paste -d " " packages versions > /tmp/package_versions.txt'
+              elif [ "${DIST_IMAGE}" == "ubuntu" ]; then
+                docker run --rm --entrypoint '/bin/sh' -v ${TEMPDIR}:/tmp ${LOCAL_CONTAINER} -c '\
+                  apt -qq list --installed | awk "{print \$1,\$2}" > /tmp/package_versions.txt'
+              fi
+              if [ "$(md5sum ${TEMPDIR}/package_versions.txt | cut -c1-8 )" != "${PACKAGE_TAG}" ]; then
+                git clone https://github.com/${LS_USER}/${LS_REPO}.git ${TEMPDIR}/${LS_REPO}
+                git --git-dir ${TEMPDIR}/${LS_REPO}/.git checkout -f master
+                cp ${TEMPDIR}/package_versions.txt ${TEMPDIR}/${LS_REPO}/
+                cd ${TEMPDIR}/${LS_REPO}/
+                git --git-dir ${TEMPDIR}/${LS_REPO}/.git add package_versions.txt
+                git --git-dir ${TEMPDIR}/${LS_REPO}/.git commit -m 'Bot Updating Package Versions'
+                git --git-dir ${TEMPDIR}/${LS_REPO}/.git push https://LinuxServer-CI:${GITHUB_TOKEN}@github.com/${LS_USER}/${LS_REPO}.git --all
+                echo "true" > /tmp/packages-${COMMIT_SHA}-${BUILD_NUMBER}
+              else
+                echo "false" > /tmp/packages-${COMMIT_SHA}-${BUILD_NUMBER}
+              fi
+              rm -Rf ${TEMPDIR}'''
+        script{
+          env.PACKAGE_UPDATED = sh(
+            script: '''cat /tmp/packages-${COMMIT_SHA}-${BUILD_NUMBER}''',
+            returnStdout: true).trim()
+        }
+      }
+    }
+    // Exit the build if the package file was just updated
+    stage('PACKAGE-exit') {
+      when {
+        branch "master"
+        environment name: 'CHANGE_ID', value: ''
+        environment name: 'PACKAGE_UPDATED', value: 'true'
+        environment name: 'EXIT_STATUS', value: ''
+      }
+      steps {
+        script{
+          env.EXIT_STATUS = 'ABORTED'
+        }
+      }
+    }
+    // Exit the build if this is just a package check and there are no changes to push
+    stage('PACKAGECHECK-exit') {
+      when {
+        branch "master"
+        environment name: 'CHANGE_ID', value: ''
+        environment name: 'PACKAGE_UPDATED', value: 'false'
+        environment name: 'EXIT_STATUS', value: ''
+        expression {
+          params.PACKAGE_CHECK == 'true'
+        }
+      }
+      steps {
+        script{
+          env.EXIT_STATUS = 'ABORTED'
+        }
+      }
+    }
     /* #######
        Testing
        ####### */
@@ -301,6 +391,7 @@ pipeline {
     stage('Test') {
       when {
         environment name: 'CI', value: 'true'
+        environment name: 'EXIT_STATUS', value: ''
       }
       steps {
         withCredentials([
@@ -308,6 +399,7 @@ pipeline {
           string(credentialsId: 'spaces-secret', variable: 'DO_SECRET')
         ]) {
           sh '''#! /bin/bash
+                set -e
                 docker pull lsiodev/ci:latest
                 if [ "${MULTIARCH}" == "true" ]; then
                   docker pull lsiodev/buildcache:arm32v6-${COMMIT_SHA}-${BUILD_NUMBER}
@@ -326,6 +418,7 @@ pipeline {
                 -e BASE=\"${DIST_IMAGE}\" \
                 -e SECRET_KEY=\"${DO_SECRET}\" \
                 -e ACCESS_KEY=\"${DO_KEY}\" \
+                -e DOCKER_ENV=\"${CI_DOCKERENV}\" \
                 -e WEB_SCREENSHOT=\"${CI_WEB}\" \
                 -e WEB_AUTH=\"${CI_AUTH}\" \
                 -e WEB_PATH=\"${CI_WEBPATH}\" \
@@ -346,6 +439,7 @@ pipeline {
     stage('Docker-Push-Single') {
       when {
         environment name: 'MULTIARCH', value: 'false'
+        environment name: 'EXIT_STATUS', value: ''
       }
       steps {
         withCredentials([
@@ -370,6 +464,7 @@ pipeline {
     stage('Docker-Push-Multi') {
       when {
         environment name: 'MULTIARCH', value: 'true'
+        environment name: 'EXIT_STATUS', value: ''
       }
       steps {
         withCredentials([
@@ -402,17 +497,17 @@ pipeline {
           sh "docker manifest push --purge ${IMAGE}:latest || :"
           sh "docker manifest create ${IMAGE}:latest ${IMAGE}:amd64-latest ${IMAGE}:arm32v6-latest ${IMAGE}:arm64v8-latest"
           sh "docker manifest annotate ${IMAGE}:latest ${IMAGE}:arm32v6-latest --os linux --arch arm"
-          sh "docker manifest annotate ${IMAGE}:latest ${IMAGE}:arm64v8-latest --os linux --arch arm64 --variant armv8"
+          sh "docker manifest annotate ${IMAGE}:latest ${IMAGE}:arm64v8-latest --os linux --arch arm64 --variant v8"
           sh "docker manifest push --purge ${IMAGE}:${EXT_RELEASE}-ls${LS_TAG_NUMBER} || :"
           sh "docker manifest create ${IMAGE}:${META_TAG} ${IMAGE}:amd64-${META_TAG} ${IMAGE}:arm32v6-${META_TAG} ${IMAGE}:arm64v8-${META_TAG}"
           sh "docker manifest annotate ${IMAGE}:${META_TAG} ${IMAGE}:arm32v6-${META_TAG} --os linux --arch arm"
-          sh "docker manifest annotate ${IMAGE}:${META_TAG} ${IMAGE}:arm64v8-${META_TAG} --os linux --arch arm64 --variant armv8"
+          sh "docker manifest annotate ${IMAGE}:${META_TAG} ${IMAGE}:arm64v8-${META_TAG} --os linux --arch arm64 --variant v8"
           sh "docker manifest push --purge ${IMAGE}:latest"
           sh "docker manifest push --purge ${IMAGE}:${META_TAG}"
         }
       }
     }
-    // If this is a public release tag it in the LS Github and push a changelog from external repo and our internal one
+    // If this is a public release tag it in the LS Github
     stage('Github-Tag-Push-Release') {
       when {
         branch "master"
@@ -420,6 +515,7 @@ pipeline {
           env.LS_RELEASE != env.EXT_RELEASE + '-pkg-' + env.PACKAGE_TAG + '-ls' + env.LS_TAG_NUMBER
         }
         environment name: 'CHANGE_ID', value: ''
+        environment name: 'EXIT_STATUS', value: ''
       }
       steps {
         echo "Pushing New tag for current commit ${EXT_RELEASE}-pkg-${PACKAGE_TAG}-ls${LS_TAG_NUMBER}"
@@ -445,6 +541,7 @@ pipeline {
     stage('Sync-README') {
       when {
         environment name: 'CHANGE_ID', value: ''
+        environment name: 'EXIT_STATUS', value: ''
       }
       steps {
         withCredentials([
@@ -461,7 +558,7 @@ pipeline {
                   -e DOCKERHUB_USERNAME=$DOCKERUSER \
                   -e DOCKERHUB_PASSWORD=$DOCKERPASS \
                   -e GIT_REPOSITORY=${LS_USER}/${LS_REPO} \
-                  -e DOCKER_REPOSITORY=${DOCKERHUB_IMAGE} \
+                  -e DOCKER_REPOSITORY=${IMAGE} \
                   -e GIT_BRANCH=master \
                   lsiodev/readme-sync bash -c 'node sync' '''
         }
@@ -472,15 +569,22 @@ pipeline {
      Send status to Discord
      ###################### */
   post {
-    success {
-      sh ''' curl -X POST --data '{"avatar_url": "https://wiki.jenkins-ci.org/download/attachments/2916393/headshot.png","embeds": [{"color": 1681177,\
-             "description": "**Build:**  '${BUILD_NUMBER}'\\n**CI Results:**  '${CI_URL}'\\n**Status:**  Success\\n**Job:** '${RUN_DISPLAY_URL}'\\n**Change:** '${CODE_URL}'\\n**External Release:**: '${RELEASE_LINK}'\\n**DockerHub:** '${DOCKERHUB_LINK}'\\n"}],\
-             "username": "Jenkins"}' ${BUILDS_DISCORD} '''
-    }
-    failure {
-      sh ''' curl -X POST --data '{"avatar_url": "https://wiki.jenkins-ci.org/download/attachments/2916393/headshot.png","embeds": [{"color": 16711680,\
-             "description": "**Build:**  '${BUILD_NUMBER}'\\n**CI Results:**  '${CI_URL}'\\n**Status:**  failure\\n**Job:** '${RUN_DISPLAY_URL}'\\n**Change:** '${CODE_URL}'\\n**External Release:**: '${RELEASE_LINK}'\\n**DockerHub:** '${DOCKERHUB_LINK}'\\n"}],\
-             "username": "Jenkins"}' ${BUILDS_DISCORD} '''
+    always {
+      script{
+        if (env.EXIT_STATUS == "ABORTED"){
+          sh 'echo "build aborted"'
+        }
+        else if (currentBuild.currentResult == "SUCCESS"){
+          sh ''' curl -X POST --data '{"avatar_url": "https://wiki.jenkins-ci.org/download/attachments/2916393/headshot.png","embeds": [{"color": 1681177,\
+                 "description": "**Build:**  '${BUILD_NUMBER}'\\n**CI Results:**  '${CI_URL}'\\n**Status:**  Success\\n**Job:** '${RUN_DISPLAY_URL}'\\n**Change:** '${CODE_URL}'\\n**External Release:**: '${RELEASE_LINK}'\\n**DockerHub:** '${DOCKERHUB_LINK}'\\n"}],\
+                 "username": "Jenkins"}' ${BUILDS_DISCORD} '''
+        }
+        else {
+          sh ''' curl -X POST --data '{"avatar_url": "https://wiki.jenkins-ci.org/download/attachments/2916393/headshot.png","embeds": [{"color": 16711680,\
+                 "description": "**Build:**  '${BUILD_NUMBER}'\\n**CI Results:**  '${CI_URL}'\\n**Status:**  failure\\n**Job:** '${RUN_DISPLAY_URL}'\\n**Change:** '${CODE_URL}'\\n**External Release:**: '${RELEASE_LINK}'\\n**DockerHub:** '${DOCKERHUB_LINK}'\\n"}],\
+                 "username": "Jenkins"}' ${BUILDS_DISCORD} '''
+        }
+      }
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ Here are some example snippets to help you get started creating a container.
 ```
 docker create \
   --name=sickchill \
-  -e PUID=1001 \
-  -e PGID=1001 \
+  -e PUID=1000 \
+  -e PGID=1000 \
   -e PGID=<yourUID> \
   -e PUID=<yourGID> \
   -e TZ=<yourdbpass> \
@@ -78,8 +78,8 @@ services:
     image: linuxserver/sickchill
     container_name: sickchill
     environment:
-      - PUID=1001
-      - PGID=1001
+      - PUID=1000
+      - PGID=1000
       - PGID=<yourUID>
       - PUID=<yourGID>
       - TZ=<yourdbpass>
@@ -89,7 +89,6 @@ services:
       - <path to data>:/tv
     ports:
       - 8081:8081
-    mem_limit: 4096m
     restart: unless-stopped
 ```
 
@@ -100,8 +99,8 @@ Container images are configured using parameters passed at runtime (such as thos
 | Parameter | Function |
 | :----: | --- |
 | `-p 8081` | will map the container's port 8081 to port 8081 on the host |
-| `-e PUID=1001` | for UserID - see below for explanation |
-| `-e PGID=1001` | for GroupID - see below for explanation |
+| `-e PUID=1000` | for UserID - see below for explanation |
+| `-e PGID=1000` | for GroupID - see below for explanation |
 | `-e PGID=<yourUID>` | specify your UID |
 | `-e PUID=<yourGID>` | specify your GID |
 | `-e TZ=<yourdbpass>` | specify your TimeZone e.g. Europe/London |
@@ -115,11 +114,11 @@ When using volumes (`-v` flags) permissions issues can arise between the host OS
 
 Ensure any volume directories on the host are owned by the same user you specify and any permissions issues will vanish like magic.
 
-In this instance `PUID=1001` and `PGID=1001`, to find yours use `id user` as below:
+In this instance `PUID=1000` and `PGID=1000`, to find yours use `id user` as below:
 
 ```
   $ id username
-    uid=1001(dockeruser) gid=1001(dockergroup) groups=1001(dockergroup)
+    uid=1000(dockeruser) gid=1000(dockergroup) groups=1000(dockergroup)
 ```
 
 
@@ -153,9 +152,20 @@ Below are the instructions for updating containers:
 * Start the new container: `docker start sickchill`
 * You can also remove the old dangling images: `docker image prune`
 
+### Via Taisun auto-updater (especially useful if you don't remember the original parameters)
+* Pull the latest image at its tag and replace it with the same env variables in one shot:
+  ```
+  docker run --rm \
+  -v /var/run/docker.sock:/var/run/docker.sock taisun/updater \
+  --oneshot sickchill
+  ```
+* You can also remove the old dangling images: `docker image prune`
+
 ### Via Docker Compose
-* Update the image: `docker-compose pull linuxserver/sickchill`
-* Let compose update containers as necessary: `docker-compose up -d`
+* Update all images: `docker-compose pull`
+  * or update a single image: `docker-compose pull sickchill`
+* Let compose update all containers as necessary: `docker-compose up -d`
+  * or update a single container: `docker-compose up -d sickchill`
 * You can also remove the old dangling images: `docker image prune`
 
 ## Versions

--- a/README.md
+++ b/README.md
@@ -1,0 +1,163 @@
+[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)](https://linuxserver.io)
+
+The [LinuxServer.io](https://linuxserver.io) team brings you another container release featuring :-
+
+ * regular and timely application updates
+ * easy user mappings (PGID, PUID)
+ * custom base image with s6 overlay
+ * weekly base OS updates with common layers across the entire LinuxServer.io ecosystem to minimise space usage, down time and bandwidth
+ * regular security updates
+
+Find us at:
+* [Discord](https://discord.gg/YWrKVTn) - realtime support / chat with the community and the team.
+* [IRC](https://irc.linuxserver.io) - on freenode at `#linuxserver.io`. Our primary support channel is Discord.
+* [Blog](https://blog.linuxserver.io) - all the things you can do with our containers including How-To guides, opinions and much more!
+* [Podcast](https://anchor.fm/linuxserverio) - on hiatus. Coming back soon (late 2018).
+
+# [linuxserver/sickchill](https://github.com/linuxserver/docker-sickchill)
+[![](https://img.shields.io/discord/354974912613449730.svg?logo=discord&label=LSIO%20Discord&style=flat-square)](https://discord.gg/YWrKVTn)
+[![](https://images.microbadger.com/badges/version/linuxserver/sickchill.svg)](https://microbadger.com/images/linuxserver/sickchill "Get your own version badge on microbadger.com")
+[![](https://images.microbadger.com/badges/image/linuxserver/sickchill.svg)](https://microbadger.com/images/linuxserver/sickchill "Get your own version badge on microbadger.com")
+![Docker Pulls](https://img.shields.io/docker/pulls/linuxserver/sickchill.svg)
+![Docker Stars](https://img.shields.io/docker/stars/linuxserver/sickchill.svg)
+[![Build Status](https://ci.linuxserver.io/buildStatus/icon?job=Docker-Pipeline-Builders/docker-sickchill/master)](https://ci.linuxserver.io/job/Docker-Pipeline-Builders/job/docker-sickchill/job/master/)
+[![](https://lsio-ci.ams3.digitaloceanspaces.com/linuxserver/sickchill/latest/badge.svg)](https://lsio-ci.ams3.digitaloceanspaces.com/linuxserver/sickchill/latest/index.html)
+
+[Sickchill](https://github.com/SickChill/SickChill) is an Automatic Video Library Manager for TV Shows. It watches for new episodes of your favorite shows, and when they are posted it does its magic. 
+
+
+[![sickchill](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/sickrage-banner.png)](https://github.com/SickChill/SickChill)
+
+## Supported Architectures
+
+Our images support multiple architectures such as `x86-64`, `arm64` and `armhf`. We utilise the docker manifest for multi-platform awareness. More information is available from docker [here](https://github.com/docker/distribution/blob/master/docs/spec/manifest-v2-2.md#manifest-list) and our announcement [here](https://blog.linuxserver.io/2019/02/21/the-lsio-pipeline-project/). 
+
+Simply pulling `linuxserver/sickchill` should retrieve the correct image for your arch, but you can also pull specific arch images via tags.
+
+The architectures supported by this image are:
+
+| Architecture | Tag |
+| :----: | --- |
+| x86-64 | amd64-latest |
+| arm64 | arm64v8-latest |
+| armhf | arm32v6-latest |
+
+
+## Usage
+
+Here are some example snippets to help you get started creating a container.
+
+### docker
+
+```
+docker create \
+  --name=sickchill \
+  -e PUID=1001 \
+  -e PGID=1001 \
+  -e PGID=<yourUID> \
+  -e PUID=<yourGID> \
+  -e TZ=<yourdbpass> \
+  -p 8081:8081 \
+  -v <path to data>:/config \
+  -v <path to data>:/downloads \
+  -v <path to data>:/tv \
+  --restart unless-stopped \
+  linuxserver/sickchill
+```
+
+
+### docker-compose
+
+Compatible with docker-compose v2 schemas.
+
+```
+---
+version: "2"
+services:
+  sickchill:
+    image: linuxserver/sickchill
+    container_name: sickchill
+    environment:
+      - PUID=1001
+      - PGID=1001
+      - PGID=<yourUID>
+      - PUID=<yourGID>
+      - TZ=<yourdbpass>
+    volumes:
+      - <path to data>:/config
+      - <path to data>:/downloads
+      - <path to data>:/tv
+    ports:
+      - 8081:8081
+    mem_limit: 4096m
+    restart: unless-stopped
+```
+
+## Parameters
+
+Container images are configured using parameters passed at runtime (such as those above). These parameters are separated by a colon and indicate `<external>:<internal>` respectively. For example, `-p 8080:80` would expose port `80` from inside the container to be accessible from the host's IP on port `8080` outside the container.
+
+| Parameter | Function |
+| :----: | --- |
+| `-p 8081` | will map the container's port 8081 to port 8081 on the host |
+| `-e PUID=1001` | for UserID - see below for explanation |
+| `-e PGID=1001` | for GroupID - see below for explanation |
+| `-e PGID=<yourUID>` | specify your UID |
+| `-e PUID=<yourGID>` | specify your GID |
+| `-e TZ=<yourdbpass>` | specify your TimeZone e.g. Europe/London |
+| `-v /config` | this will store config on the docker host |
+| `-v /downloads` | this will store any downloaded data on the docker host |
+| `-v /tv` | this will allow sickchill to view what you already have |
+
+## User / Group Identifiers
+
+When using volumes (`-v` flags) permissions issues can arise between the host OS and the container, we avoid this issue by allowing you to specify the user `PUID` and group `PGID`.
+
+Ensure any volume directories on the host are owned by the same user you specify and any permissions issues will vanish like magic.
+
+In this instance `PUID=1001` and `PGID=1001`, to find yours use `id user` as below:
+
+```
+  $ id username
+    uid=1001(dockeruser) gid=1001(dockergroup) groups=1001(dockergroup)
+```
+
+
+&nbsp;
+## Application Setup
+
+Web interface is at `<your ip>:8081` , set paths for downloads, tv-shows to match docker mappings via the webui.
+
+
+
+## Support Info
+
+* Shell access whilst the container is running: `docker exec -it sickchill /bin/bash`
+* To monitor the logs of the container in realtime: `docker logs -f sickchill`
+* container version number 
+  * `docker inspect -f '{{ index .Config.Labels "build_version" }}' sickchill`
+* image version number
+  * `docker inspect -f '{{ index .Config.Labels "build_version" }}' linuxserver/sickchill`
+
+## Updating Info
+
+Most of our images are static, versioned, and require an image update and container recreation to update the app inside. With some exceptions (ie. nextcloud, plex), we do not recommend or support updating apps inside the container. Please consult the [Application Setup](#application-setup) section above to see if it is recommended for the image.  
+  
+Below are the instructions for updating containers:  
+  
+### Via Docker Run/Create
+* Update the image: `docker pull linuxserver/sickchill`
+* Stop the running container: `docker stop sickchill`
+* Delete the container: `docker rm sickchill`
+* Recreate a new container with the same docker create parameters as instructed above (if mapped correctly to a host folder, your `/config` folder and settings will be preserved)
+* Start the new container: `docker start sickchill`
+* You can also remove the old dangling images: `docker image prune`
+
+### Via Docker Compose
+* Update the image: `docker-compose pull linuxserver/sickchill`
+* Let compose update containers as necessary: `docker-compose up -d`
+* You can also remove the old dangling images: `docker image prune`
+
+## Versions
+
+* **10.10.18:** - Initial Release.

--- a/jenkins-vars.yml
+++ b/jenkins-vars.yml
@@ -2,7 +2,7 @@
 
 # jenkins variables
 project_name: docker-sickchill
-external_type: github_stable
+external_type: github_commit
 release_type: stable
 release_tag: latest
 ls_branch: master
@@ -10,7 +10,7 @@ repo_vars:
   - EXT_GIT_BRANCH = 'master'
   - EXT_USER = 'sickchill'
   - EXT_REPO = 'sickchill'
-  - BUILD_VERSION_ARG = 'SICKCHILL_RELEASE'
+  - BUILD_VERSION_ARG = 'SICKCHILL_COMMIT'
   - LS_USER = 'linuxserver'
   - LS_REPO = 'docker-sickchill'
   - CONTAINER_NAME = 'sickchill'

--- a/jenkins-vars.yml
+++ b/jenkins-vars.yml
@@ -1,0 +1,29 @@
+---
+
+# jenkins variables
+project_name: docker-sickchill
+external_type: github_stable
+release_type: stable
+release_tag: latest
+ls_branch: master
+repo_vars:
+  - EXT_GIT_BRANCH = 'master'
+  - EXT_USER = 'sickchill'
+  - EXT_REPO = 'sickchill'
+  - BUILD_VERSION_ARG = 'SICKCHILL_RELEASE'
+  - LS_USER = 'linuxserver'
+  - LS_REPO = 'docker-sickchill'
+  - CONTAINER_NAME = 'sickchill'
+  - DOCKERHUB_IMAGE = 'linuxserver/sickchill'
+  - DEV_DOCKERHUB_IMAGE = 'lsiodev/sickchill'
+  - PR_DOCKERHUB_IMAGE = 'lspipepr/sickchill'
+  - DIST_IMAGE = 'alpine'
+  - MULTIARCH = 'true'
+  - CI = 'true'
+  - CI_WEB = 'true'
+  - CI_PORT = '8081'
+  - CI_SSL = 'false'
+  - CI_DELAY = '120'
+  - CI_DOCKERENV = 'TZ=Europe/London'
+  - CI_AUTH = 'user:password'
+  - CI_WEBPATH = ''


### PR DESCRIPTION
This image is intended to replace linuxserver/docker-sickrage as sickrage is no longer supported by LinuxServer.io

linuxserver/docker-sickrage has been pulling from sickchill repos since October 2018, however the repo has not been renamed. This repository is now to completely replace the old one.

Once this is merged, the job will need to be set up in Jenkins with trigger, and the old sickrage repo will need a deprecation message. 

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

