### PR TITLE
Only set permissions when needed

### DIFF
--- a/root/etc/cont-init.d/30-config
+++ b/root/etc/cont-init.d/30-config
@@ -1,6 +1,27 @@
 #!/usr/bin/with-contenv bash
 
-# permissions
-chown -R abc:abc \
-	/app \
-	/config
+# function to randomly sample 5 files for their owner and only chown if not abc
+chowner () {
+files=(${1}/*)
+for i in {1..5}; do
+        user=$(stat -c '%U' $(printf "%s\n" "${files[RANDOM % ${#files[@]}]}"))
+        if [ "${user}" != "abc" ]; then
+                chown -R abc:abc ${1}
+                break
+        fi
+done
+}
+
+# permissions
+echo "Setting permissions"
+abc_dirs=( \
+/app \
+/config \
+)
+for i in "${abc_dirs[@]}"; do
+        if [ "$(ls -A ${i})" ]; then
+                chowner ${i}
+        else
+                chown -R abc:abc ${i}
+        fi
+done


### PR DESCRIPTION
This will speed up boot by only run chown when needed.
Solution taken from https://github.com/linuxserver/docker-tvheadend/blob/master/root/etc/cont-init.d/30-config#L22

